### PR TITLE
AP Cost, Dupe Detection, Remove Item

### DIFF
--- a/src/main/ffta/enginehacks/jobHacks.ts
+++ b/src/main/ffta/enginehacks/jobHacks.ts
@@ -61,13 +61,15 @@ export function changeRaceAbilities(
   // Examples: Fire, Shield Bearer, Counter, Bow Combo
   let abilityRecord = flattenRaceMapAbilities(raceAbilities);
 
-  // Always ban Knife and Limit Glove, since they are not learned normally
+  // Always ban Knife, Limit Glove, and Item, since they are not learned normally
   let knife = abilityRecord.find((ability) => ability.displayName === "Knife");
   if (knife) knife.allowed = false;
   let limitGlove = abilityRecord.find(
     (ability) => ability.displayName === "Limit Glove"
   );
   if (limitGlove) limitGlove.allowed = false;
+  let item = abilityRecord.find((ability) => ability.displayName === "Item");
+  if (item) item.allowed = false;
 
   // Remove banned abilities from the pool
   abilityRecord = abilityRecord.filter((ability) => ability.allowed);
@@ -176,7 +178,7 @@ function abilityReplace(
     let newAbility = new FFTARaceAbility(ability.memory, name);
     newAbility.copy(selectedAbility);
     newRaceAbilities.push(newAbility);
-    newAbility.apCost = 0;
+    newAbility.apCost = selectedAbility.apCost;
 
     // If shuffling abilities, remove the selected ability from the list
     // Uses memory address for duplicate case


### PR DESCRIPTION
! Fixed issue where AP Costs were all 0
! Removed "Item" as an ability from the pool, since only alchemists can use it
+ Added duplicate detection on abilities to reduce menu clutter (duplicate abilities are not replaced)
++ Duplicate A-Abilities within a single job are removed (Dragoon will not master "Fira" twice, but Dragoon and Bishop can both have "Fira")
++ Duplicate S, R, and C abilities across jobs are removed (a unit will not master more than one "Concentrate")