### PR TITLE
Add fixes to remove job requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffta_randomizer",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffta_randomizer",
-      "version": "3.0.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "react": "^17.0.1",
@@ -22861,6 +22861,7 @@
     },
     "y18n": {
       "version": "4.0.0",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffta_randomizer",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Randomizer for the game Final Fantasy Tactics Advance",
   "main": "./dist/main.bundle.js",
   "scripts": {

--- a/src/main/ffta/DataWrapper/FFTAMission.ts
+++ b/src/main/ffta/DataWrapper/FFTAMission.ts
@@ -19,7 +19,7 @@ const enum OFFSET {
   REQITEM1 = 0x36, // 0x01 = Magic Trophy as required
   REQITEM2 = 0x37,
   REQSKILL = 0x38, // 0x01 = Combat
-  REQSKILLAMOUNT = 0x39, //0x01 = level 8? maybe tied to "difficulty"
+  REQJOB = 0x39, //0x01 = level 8? maybe tied to "difficulty"
   PRICE = 0x3e,
   TIMEOUTDAYS = 0x40,
   MISSIONDISPLAY = 0x41, // Hide Item 1, Hide Item 2, ?? ?? // Repeatable, ??, ??, No Cancel
@@ -381,17 +381,17 @@ export class FFTAMission extends FFTAObject {
     return this._requiredSkill.value;
   }
 
-  private _requiredSkillAmount: ROMProperty = {
-    byteOffset: OFFSET.REQSKILLAMOUNT,
+  private _requiredJob: ROMProperty = {
+    byteOffset: OFFSET.REQJOB,
     byteLength: 1,
     displayName: "Could not retrieve.",
     value: 0,
   };
-  set requiredSkillAmount(id: number) {
-    this._requiredSkillAmount.value = id;
+  set requiredJob(id: number) {
+    this._requiredJob.value = id;
   }
-  get requiredSkillAmount(): number {
-    return this._requiredSkillAmount.value;
+  get requiredJob(): number {
+    return this._requiredJob.value;
   }
 
   /*

--- a/src/main/ffta/DataWrapper/FFTAMission.ts
+++ b/src/main/ffta/DataWrapper/FFTAMission.ts
@@ -368,6 +368,32 @@ export class FFTAMission extends FFTAObject {
     return this._requiredItem2.value;
   }
 
+  private _requiredSkill: ROMProperty = {
+    byteOffset: OFFSET.REQSKILL,
+    byteLength: 1,
+    displayName: "Could not retrieve.",
+    value: 0,
+  };
+  set requiredSkill(id: number) {
+    this._requiredSkill.value = id;
+  }
+  get requiredSkill(): number {
+    return this._requiredSkill.value;
+  }
+
+  private _requiredSkillAmount: ROMProperty = {
+    byteOffset: OFFSET.REQSKILLAMOUNT,
+    byteLength: 1,
+    displayName: "Could not retrieve.",
+    value: 0,
+  };
+  set requiredSkillAmount(id: number) {
+    this._requiredSkillAmount.value = id;
+  }
+  get requiredSkillAmount(): number {
+    return this._requiredSkillAmount.value;
+  }
+
   /*
   private _requiredJob: ROMProperty = {
     byteOffset: ??,

--- a/src/main/ffta/FFTAData.ts
+++ b/src/main/ffta/FFTAData.ts
@@ -879,6 +879,7 @@ export class FFTAData {
         break;
       case "locked":
         JobHacks.lockAllJobs(this.jobs);
+        MissionHacks.clearMissionJobRequirements(this.missions);
         break;
       default:
         throw new Error("case: " + option + " unhandled!");

--- a/src/main/ffta/FFTAData.ts
+++ b/src/main/ffta/FFTAData.ts
@@ -1090,9 +1090,11 @@ export class FFTAData {
         break;
       case "none":
         this.rom = CutsceneHacks.skipCutscenes(this.rom, false);
+        MissionHacks.clearMissionStatRequirements(this.missions);
         break;
       case "noTutorial":
         this.rom = CutsceneHacks.skipCutscenes(this.rom, true);
+        MissionHacks.clearMissionStatRequirements(this.missions);
         break;
       default:
         throw new Error("case: " + option + " unhandled!");

--- a/src/main/ffta/enginehacks/missionHacks.ts
+++ b/src/main/ffta/enginehacks/missionHacks.ts
@@ -74,7 +74,6 @@ export function highestMissionLevels(fftaData: FFTAData) {
 export function clearMissionStatRequirements(missions: Array<FFTAMission>) {
   missions.forEach((mission) => {
     mission.requiredSkill = 0;
-    // mission.requiredSkillAmount = 0;
   });
 }
 

--- a/src/main/ffta/enginehacks/missionHacks.ts
+++ b/src/main/ffta/enginehacks/missionHacks.ts
@@ -74,7 +74,17 @@ export function highestMissionLevels(fftaData: FFTAData) {
 export function clearMissionStatRequirements(missions: Array<FFTAMission>) {
   missions.forEach((mission) => {
     mission.requiredSkill = 0;
-    mission.requiredSkillAmount = 0;
+    // mission.requiredSkillAmount = 0;
+  });
+}
+
+/**
+ * Removes the clan stat requirements for missions.
+ * @param missions - Array of missions to clear
+ */
+export function clearMissionJobRequirements(missions: Array<FFTAMission>) {
+  missions.forEach((mission) => {
+    mission.requiredJob = 0;
   });
 }
 

--- a/src/main/ffta/enginehacks/missionHacks.ts
+++ b/src/main/ffta/enginehacks/missionHacks.ts
@@ -68,6 +68,17 @@ export function highestMissionLevels(fftaData: FFTAData) {
 }
 
 /**
+ * Removes the clan stat requirements for missions.
+ * @param missions - Array of missions to clear
+ */
+export function clearMissionStatRequirements(missions: Array<FFTAMission>) {
+  missions.forEach((mission) => {
+    mission.requiredSkill = 0;
+    mission.requiredSkillAmount = 0;
+  });
+}
+
+/**
  * Sets the two orbs on Frosty Mage to level 50
  * @param rom - A buffer holding FFTA
  */


### PR DESCRIPTION
This is a backend fix to counteract the unintentional issue of clan skills not leveling up when cutscene skip options are enabled. At this time, it's unclear why this occurs. The temporary and retroactive fix is to remove clan skill requirements from missions when these options are selected. A similar change has been enabled when "Lock Jobs" is enabled. The required jobs on missions will be cleared in this case. No UI options have been added at this time.